### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -16,6 +16,9 @@ concurrency:
     group: ${{ github.ref }}-validation
     cancel-in-progress: true
 
+permissions:
+    contents: read
+
 jobs:
     dns:
         name: DNS


### PR DESCRIPTION
Potential fix for [https://github.com/is-cool-me/register/security/code-scanning/4](https://github.com/is-cool-me/register/security/code-scanning/4)

Add an explicit `permissions` block at the workflow root in `.github/workflows/validation.yml`, immediately after `concurrency` (or before `jobs`). Since both jobs are validation-only and only need repository read access for checkout and reading files, set:

- `contents: read`

This applies to all jobs unless overridden and preserves existing functionality while enforcing least privilege for `GITHUB_TOKEN`. No imports, methods, or dependencies are needed for YAML workflow changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
