### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/save-pr-number.yml
+++ b/.github/workflows/save-pr-number.yml
@@ -5,6 +5,9 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/is-cool-me/register/security/code-scanning/3](https://github.com/is-cool-me/register/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: define workflow-level permissions with `contents: read`, which is sufficient for this workflow’s shown steps (shell commands + `actions/upload-artifact`) and does not change functionality.

Edit file **`.github/workflows/save-pr-number.yml`** near the top-level keys (after `on` and before `jobs`, or immediately under `name`/`on` as valid YAML). No imports/dependencies/methods are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
