### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/raw-api.yml
+++ b/.github/workflows/raw-api.yml
@@ -14,6 +14,9 @@ concurrency:
     group: ${{ github.ref }}-raw-api
     cancel-in-progress: true
 
+permissions:
+    contents: read
+
 jobs:
     update:
         name: Update


### PR DESCRIPTION
Potential fix for [https://github.com/is-cool-me/register/security/code-scanning/2](https://github.com/is-cool-me/register/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root, just below `concurrency` (before `jobs`), to enforce least privilege for all jobs by default.  
For this workflow, the best minimal non-breaking setting is:

- `contents: read`

This satisfies CodeQL’s recommendation and keeps existing functionality intact, since write/push actions here rely on the generated GitHub App token passed explicitly, not broad default `GITHUB_TOKEN` write access.

File to edit:
- `.github/workflows/raw-api.yml`  
Region:
- Insert between current lines 16 and 17 (after `concurrency` block, before `jobs:`).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
