### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ concurrency:
     group: ${{ github.ref }}-publish
     cancel-in-progress: false
 
+permissions:
+    contents: read
+
 jobs:
     dns:
         name: DNS


### PR DESCRIPTION
Potential fix for [https://github.com/is-cool-me/register/security/code-scanning/1](https://github.com/is-cool-me/register/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged.  
Best fix here: set workflow-level permissions to `contents: read`, which satisfies `actions/checkout` and does not change functional behavior of this workflow.

**Where to change:** `.github/workflows/publish.yml`, near the top-level keys (after `concurrency` or before `jobs`).

**What to add:**
```yml
permissions:
    contents: read
```

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
