### PR TITLE
BETA: Register test.is-pro.dev

### DIFF
--- a/domains/test.is-pro.dev.json
+++ b/domains/test.is-pro.dev.json
@@ -1,0 +1,12 @@
+{
+    "domain": "is-pro.dev",
+    "subdomain": "test",
+    "owner": {
+        "username": "LightHostingFree",
+        "email": "admin@lighthosting.eu.org"
+    },
+    "records": {
+        "CNAME": "Google.com"
+    },
+    "proxied": false
+}


### PR DESCRIPTION
Added `test.is-pro.dev` using the [dashboard](https://dash.is-pro.dev).