### PR TITLE
BETA: Register sushismp.is-pro.dev

### DIFF
--- a/domains/sushismp.is-pro.dev.json
+++ b/domains/sushismp.is-pro.dev.json
@@ -1,0 +1,12 @@
+{
+    "domain": "is-pro.dev",
+    "subdomain": "sushismp",
+    "owner": {
+        "username": "chermaxim2013-cmyk",
+        "email": "chermaxim2013@gmail.com"
+    },
+    "records": {
+        "CNAME": "due-tactless.gl.joinmc.link"
+    },
+    "proxied": false
+}


### PR DESCRIPTION
Added `sushismp.is-pro.dev` using the [dashboard](https://dash.is-pro.dev).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/is-cool-me/register/pull/385" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->